### PR TITLE
Highlight current manual page in table of contents

### DIFF
--- a/_layouts/manual.html
+++ b/_layouts/manual.html
@@ -31,7 +31,7 @@
         </div>
         <div class="col-md-4">
             <h2>Contents</h2>
-            {{ manual_index(site) }}
+            {{ manual_index(this, site) }}
         </div>
     </div>
 

--- a/_layouts/utils.html
+++ b/_layouts/utils.html
@@ -496,14 +496,19 @@
 {%- endmacro -%}
 
 
-{%- macro manual_index(site) -%}
+{%- macro manual_index(page, site) -%}
     <ul>
         <li>
             <a href="{{ site.reflinks["/manual"].url }}">{{ site.reflinks["/manual"].title }}</a>
             <ul>
-                {% for page in site.reflinks["/manual"].content %}
-                    <li>
-                        <a href="{{ page.url }}">{{ page.title }}</a>
+                {% for manpage in site.reflinks["/manual"].content %}
+                    {% if manpage.url == page.url %}
+                        {% set class="manual-current" %}
+                    {% else %}
+                        {% set class="" %}
+                    {% endif %}
+                    <li class={{ class }}>
+                        <a href="{{ manpage.url }}">{{ manpage.title }}</a>
                     </li>
                 {% endfor %}
             </ul>

--- a/css/style.css
+++ b/css/style.css
@@ -339,6 +339,10 @@ img {
     color: #aaaaaa;
 }
 
+.manual-current {
+    font-weight: bold;
+}
+
 .tag {
     background-color: #eeeeee;
     color: #333333;


### PR DESCRIPTION
Add a different style (bold) to the current manual page being displayed
in the table of contents.

Fixes #3