### PR TITLE
Split the manual into 2 sections

### DIFF
--- a/_templates/manual.html
+++ b/_templates/manual.html
@@ -11,27 +11,42 @@
       </blockquote>
     </div>
     <div class="column-nav flow">
-      <p class="text-bold font-large"><i class="fas fa-list fa-sm" aria-hidden="true"></i> Contents</p>
       <nav class="flow" aria-label="Manual">
-        <ol class="flow" role="list">
-          {%- for id in site["manual/index"]["toc_table"] %}
-            {%- if id == page.id %}
-              <li class="active">
-                <a aria-current="page" href="{{ site[id].path|relative_to(page.path) }}">
-                  {{ site[id].title }}
-                </a>
-              </li>
-            {%- else %}
-              <li>
-                <a href="{{ site[id].path|relative_to(page.path) }}">
-                  {{ site[id].title }}
-                </a>
-              </li>
-            {%- endif %}
-          {%- endfor %}
-        </ol>
+        <p class="text-bold font-large">
+          <i class="fas fa-list fa-sm" aria-hidden="true"></i> Handbook
+        </p>
+        {{ create_toc(site["manual/index"]["handbook_toc"]) }}
+        <hr>
+        <p class="text-bold font-large">
+          <i class="fas fa-list fa-sm" aria-hidden="true"></i> Technical
+        </p>
+        {{ create_toc(site["manual/index"]["technical_toc"]) }}
+        <hr>
+        <a aria-current="page" href="{{ site["manual/index"].path|relative_to(page.path) }}">
+          <i class="fas fa-arrow-left fa-sm" aria-hidden="true"></i> Back to the index
+        </a>
       </nav>
     </div>
   </div>
 {%- endblock %}
 
+
+{%- macro create_toc(toc) %}
+  <ol class="flow" role="list">
+    {%- for id in toc %}
+      {%- if id == page.id %}
+        <li class="active">
+          <a aria-current="page" href="{{ site[id].path|relative_to(page.path) }}">
+            {{ site[id].title }}
+          </a>
+        </li>
+      {%- else %}
+        <li>
+          <a href="{{ site[id].path|relative_to(page.path) }}">
+            {{ site[id].title }}
+          </a>
+        </li>
+      {%- endif %}
+    {%- endfor %}
+  </ol>
+{%- endmacro %}

--- a/_templates/manual.html
+++ b/_templates/manual.html
@@ -12,41 +12,30 @@
     </div>
     <div class="column-nav flow">
       <nav class="flow" aria-label="Manual">
-        <p class="text-bold font-large">
-          <i class="fas fa-list fa-sm" aria-hidden="true"></i> Handbook
-        </p>
-        {{ create_toc(site["manual/index"]["handbook_toc"]) }}
-        <hr>
-        <p class="text-bold font-large">
-          <i class="fas fa-list fa-sm" aria-hidden="true"></i> Technical
-        </p>
-        {{ create_toc(site["manual/index"]["technical_toc"]) }}
-        <hr>
-        <a aria-current="page" href="{{ site["manual/index"].path|relative_to(page.path) }}">
-          <i class="fas fa-arrow-left fa-sm" aria-hidden="true"></i> Back to the index
-        </a>
+        {%- for section in site["manual/index"].toc %}
+          <p class="text-bold font-large">
+            <i class="fas fa-list fa-sm" aria-hidden="true"></i>
+            {{ section.title }}
+          </p>
+          <ol class="flow">
+            {%- for id in section.pages %}
+              {%- if id == page.id %}
+                <li class="active"><a aria-current="page" href="{{ site[id].path|relative_to(page.path) }}">{{ site[id].title }} </a></li>
+              {%- else %}
+                <li><a href="{{ site[id].path|relative_to(page.path) }}">{{ site[id].title }}</a></li>
+              {%- endif %}
+            {%- endfor %}
+          </ol>
+        {%- endfor %}
+        <div class="extra-space-xs">
+        {%- if page.id != "manual/index" %}
+          <a aria-current="page" href="{{ site["manual/index"].path|relative_to(page.path) }}">
+            <i class="fas fa-arrow-left fa-sm" aria-hidden="true"></i>
+            Back to the manual
+          </a>
+        {%- endif %}
+        </div>
       </nav>
     </div>
   </div>
 {%- endblock %}
-
-
-{%- macro create_toc(toc) %}
-  <ol class="flow" role="list">
-    {%- for id in toc %}
-      {%- if id == page.id %}
-        <li class="active">
-          <a aria-current="page" href="{{ site[id].path|relative_to(page.path) }}">
-            {{ site[id].title }}
-          </a>
-        </li>
-      {%- else %}
-        <li>
-          <a href="{{ site[id].path|relative_to(page.path) }}">
-            {{ site[id].title }}
-          </a>
-        </li>
-      {%- endif %}
-    {%- endfor %}
-  </ol>
-{%- endmacro %}

--- a/css/style.css
+++ b/css/style.css
@@ -302,7 +302,7 @@ blockquote > * + *, figure > * + *, .callout > * + * {
 
 .column-body {
   flex: 3;
-  min-width: 75%;
+  min-width: 70%;
 }
 
 .column-body > nav a {
@@ -316,7 +316,7 @@ blockquote > * + *, figure > * + *, .callout > * + * {
 
 .column-nav {
   flex: 1;
-  min-width: 16ch;
+  min-width: 18ch;
   height: 100%;
   padding-left: var(--gutter);
   border-left: 2px solid var(--color-extramuted);
@@ -325,28 +325,48 @@ blockquote > * + *, figure > * + *, .callout > * + * {
   top: 0;
 }
 
-.column-nav li {
-  padding-left: var(--space-2xs);
-  border-left: 3px solid transparent;
-  line-height: 1.2;
-}
-
 .column-nav a {
   color: var(--color-muted);
 }
 
 .column-nav a:hover {
-  color: var(--color-muted);
+  color: var(--color-dark);
   text-decoration: none;
+}
+
+.column-nav ol {
+  padding-left: 0;
+}
+
+.column-nav li {
+  list-style-position: inside;
+  padding-left: var(--space-3xs);
+  border-left: 3px solid transparent;
+  line-height: 1.2;
+}
+
+.column-nav li::marker {
+  color: var(--color-muted);
 }
 
 .column-nav li:hover {
   border-left: 3px solid var(--color-secondary);
 }
 
+.column-nav li:hover::marker {
+  color: var(--color-dark);
+}
+
 .column-nav li.active {
   border-left: 3px solid var(--color-secondary);
-  font-weight: bold;
+}
+
+.column-nav li.active > a{
+  color: var(--color-dark);
+}
+
+.column-nav li.active::marker {
+  color: var(--color-dark);
 }
 
 
@@ -383,6 +403,10 @@ blockquote > * + *, figure > * + *, .callout > * + * {
 
 .extra-space-xl {
   margin-top: var(--space-3xl);
+}
+
+.extra-space-xs {
+  margin-top: var(--space-l);
 }
 
 .font-small {

--- a/manual/index.md
+++ b/manual/index.md
@@ -1,18 +1,21 @@
 ---
 title: Lab manual
-handbook_toc:
-  - manual/open-science
-  - manual/authorship
-  - manual/join
-  - manual/expectations
-  - manual/communication
-  - manual/health
-  - manual/coc
-technical_toc:
-  - manual/getting-started
-  - manual/software
-  - manual/computing
-  - manual/resources
+toc:
+   - title: Handbook
+     pages:
+       - manual/coc
+       - manual/open-science
+       - manual/expectations
+       - manual/authorship
+   - title: Guides
+     pages:
+       - manual/join
+       - manual/getting-started
+       - manual/communication
+       - manual/health
+       - manual/software
+       - manual/computing
+       - manual/resources
 ---
 
 {% import "macros.html" as macros %}
@@ -26,10 +29,16 @@ process, and general information about how we operate as a research team.
 
 ## About
 
-This document is designed to be a reference for lab members and collaborators.
-It's also part of an induction process when people join the lab.
-**The manual is a living document.** Lab members are **encouraged to submit
-fixes and improvements** to it. See the
+This document is designed to be a reference for lab members and collaborators,
+explaining how we work and what are our expectations.
+It's divided into two sections:
+
+* **{{ page.toc[0].title }}:** Lays out our core principles and work ethic.
+* **{{ page.toc[1].title }}:** Explains of how we operate and other useful
+  information.
+
+The manual is a **living document.** Lab members are encouraged to submit
+**fixes and improvements** to it. See the
 [Contributing Guide](https://github.com/compgeolab/website/blob/main/CONTRIBUTING.md)
 for this website to find out how.
 

--- a/manual/index.md
+++ b/manual/index.md
@@ -1,15 +1,15 @@
 ---
 title: Lab manual
-toc_table:
-  - manual/index
+handbook_toc:
   - manual/open-science
   - manual/authorship
   - manual/join
   - manual/expectations
-  - manual/getting-started
   - manual/communication
   - manual/health
   - manual/coc
+technical_toc:
+  - manual/getting-started
   - manual/software
   - manual/computing
   - manual/resources

--- a/manual/join.md
+++ b/manual/join.md
@@ -1,5 +1,5 @@
 ---
-title: How to join the lab
+title: Joining the lab
 ---
 
 {% import "macros.html" as macros %}


### PR DESCRIPTION
Split pages between a Handbook and Guides. Handbook has the principles and ethos. Guides has how-tos and explanations. The pages haven't changed, it's mostly just down to the table of contents being split in two.

Fixes #56 